### PR TITLE
Fixed maven dependency problem for com/google/common/collect/ImmutableMap

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,10 +40,10 @@
             <version>3.0.4</version>
         </dependency>
 	<dependency>
-	  <groupId>com.google.collections</groupId>
-	  <artifactId>google-collections</artifactId>
-	  <version>1.0</version>
-	</dependency>
+	  <groupId>com.google.guava</groupId>
+	  <artifactId>guava</artifactId>
+	  <version>12.0</version>
+      </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
When running a target I get:

Internal error in the plugin manager executing goal 'org.jasig.maven:sass-maven-plugin:1.0.1-SNAPSHOT:watch': Unable to load the mojo 'org.jasig.maven:sass-maven-plugin:1.0.1-SNAPSHOT:watch' in the plugin 'org.jasig.maven:sass-maven-plugin'. A required class is missing: com/google/common/collect/ImmutableMap
com.google.common.collect.ImmutableMap

Adding a maven dependency for com.google.common.collect solved the problem
