### PR TITLE
Sass Maven plugins fails to execute jRuby scripts. 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,18 +32,19 @@
         <dependency>
             <groupId>org.jruby</groupId>
             <artifactId>jruby-complete</artifactId>
-            <version>1.6.7.1</version>
+            <version>1.6.8</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
             <version>3.0.4</version>
         </dependency>
-	<dependency>
-	  <groupId>com.google.guava</groupId>
-	  <artifactId>guava</artifactId>
-	  <version>12.0</version>
-      </dependency>
+		<dependency>
+		  <groupId>com.google.guava</groupId>
+		  <artifactId>guava</artifactId>
+		  <version>13.0.1</version>
+	    </dependency>
+	    
     </dependencies>
 
     <build>

--- a/src/main/java/org/jasig/maven/plugin/sass/AbstractSassMojo.java
+++ b/src/main/java/org/jasig/maven/plugin/sass/AbstractSassMojo.java
@@ -106,7 +106,7 @@ public abstract class AbstractSassMojo extends AbstractMojo {
         
         //If not explicitly set place the cache location in the target dir
         if (!sassOptions.containsKey("cache_location")) {
-            final File sassCacheDir = newCanonicalFile(buildDirectory, "sass_cache");
+            final String sassCacheDir = newCanonicalFile(buildDirectory, "sass_cache");
             sassOptions.put("cache_location", "'" + sassCacheDir.toString() + "'");
         }
         
@@ -124,10 +124,10 @@ public abstract class AbstractSassMojo extends AbstractMojo {
         sassScript.append(")\n");
     }
     
-    protected File newCanonicalFile(File parent, String child) throws MojoExecutionException {
+    protected String newCanonicalFile(File parent, String child) throws MojoExecutionException {
         final File f = new File(parent, child);
         try {
-            return f.getCanonicalFile();
+            return f.getCanonicalPath().replace('\\', '/');
         }
         catch (IOException e) {
             throw new MojoExecutionException("Failed to create canonical File for: " + f, e);

--- a/src/main/java/org/jasig/maven/plugin/sass/UpdateStylesheetsMojo.java
+++ b/src/main/java/org/jasig/maven/plugin/sass/UpdateStylesheetsMojo.java
@@ -19,6 +19,7 @@
 package org.jasig.maven.plugin.sass;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.Set;
 
 import javax.script.ScriptEngine;
@@ -52,6 +53,7 @@ public class UpdateStylesheetsMojo extends AbstractSassMojo {
         
         //Execute the SASS Compliation Ruby Script
         log.info("Compiling SASS Templates");
+        
         final ScriptEngineManager scriptEngineManager = new ScriptEngineManager();
         final ScriptEngine jruby = scriptEngineManager.getEngineByName("jruby");
         try {
@@ -71,16 +73,15 @@ public class UpdateStylesheetsMojo extends AbstractSassMojo {
         //Add the SASS Template locations
         final Set<String> sassDirectories = this.findSassDirs();
         for (final String sassSubDir : sassDirectories) {
-            final File sassDir = newCanonicalFile(sassSourceDirectory, sassSubDir);
-            final File sassDestDir = newCanonicalFile(new File(baseOutputDirectory, sassSubDir), relativeOutputDirectory);
+            final String sassDir = newCanonicalFile(sassSourceDirectory, sassSubDir);
+            final String sassDestDir = newCanonicalFile(new File(baseOutputDirectory, sassSubDir), relativeOutputDirectory);
 
-            final String sassDirStr = sassDir.toString();
-            final String sassDestDirStr = sassDestDir.toString();
-            final int index = StringUtils.differenceAt(sassDirStr, sassDestDirStr);
-            log.info("Queing SASS Template for compile: " + sassDirStr.substring(index) + " => " + sassDestDirStr.substring(index));
+            final int index = StringUtils.differenceAt(sassDir, sassDestDir);
+            log.info("Queing SASS Template for compile: " + sassDir.substring(index) + " => " + sassDestDir.substring(index));
             
             sassScript.append("Sass::Plugin.add_template_location('").append(sassDir).append("', '")
-                    .append(sassDestDir).append("')\n");
+                                .append(sassDestDir).append("')\n");
+            
         }
         sassScript.append("Sass::Plugin.update_stylesheets");
         

--- a/src/main/java/org/jasig/maven/plugin/sass/WatchMojo.java
+++ b/src/main/java/org/jasig/maven/plugin/sass/WatchMojo.java
@@ -58,22 +58,20 @@ public class WatchMojo extends AbstractSassMojo {
         
         final String sassSubDir = this.findSassDir(this.skin);
             
-        final File sassDir = newCanonicalFile(sassSourceDirectory, sassSubDir);
-        final File sassDestDir = newCanonicalFile(new File(outputDirectory, sassSubDir), relativeOutputDirectory);
+        final String sassDir = newCanonicalFile(sassSourceDirectory, sassSubDir);
+        final String sassDestDir = newCanonicalFile(new File(outputDirectory, sassSubDir), relativeOutputDirectory);
 
-        final String sassSourceDirStr = sassDir.toString();
-        final String cssDestDirStr = sassDestDir.toString();
-        final int index = StringUtils.differenceAt(sassSourceDirStr, cssDestDirStr);
+        final int index = StringUtils.differenceAt(sassDir, sassDestDir);
         
         //Generate the SASS Script
-        final String sassScript = this.buildSassScript(sassSourceDirStr, cssDestDirStr);
+        final String sassScript = this.buildSassScript(sassDir, sassDestDir);
         log.debug("SASS Ruby Script:\n" + sassScript);     
         
         if (log.isDebugEnabled()) {
             log.debug("Started watching SASS Template: " + sassDir + " => " + sassDestDir);
         }
         else {
-            log.info("Started watching SASS Template: " + sassSourceDirStr.substring(index) + " => " + cssDestDirStr.substring(index));
+            log.info("Started watching SASS Template: " + sassDestDir.substring(index) + " => " + sassDestDir.substring(index));
         }
         
         final ScriptEngineManager scriptEngineManager = new ScriptEngineManager();
@@ -94,7 +92,7 @@ public class WatchMojo extends AbstractSassMojo {
             if (sassSubDir.contains(skin)) {
                 matches.add(sassSubDir);
             }
-        }
+        } 
         
         if (matches.size() == 1) {
             return matches.get(0);


### PR DESCRIPTION
The plugin fails to compile sass scripts on Windows where file separator is defined as "\" (which ultimately prevents uPortal to be build on Windows).

This commit uses '/' instead so that jRuby can execute the sass script. Also bumped a few version numbers.
