### PR TITLE
Roll back jruby until the relative path issue (jruby/235) is fixed.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>org.jruby</groupId>
             <artifactId>jruby-complete</artifactId>
-            <version>1.7.0</version>
+            <version>1.6.8</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>


### PR DESCRIPTION
This is a temporary fix for Issue #12 until jRuby can issue a fix for
https://github.com/jruby/jruby/issues/235.  jRuby 1.7.0 and 1.7.1 both
exhibit this behavior.  Rolling back to 1.6.8 allows the plugin to
actually run.  In addition, the fixes for windows applied in previous
commits will now work as well.
