### PR TITLE
Report compilation errors and optionally fail build

### DIFF
--- a/src/main/java/org/jasig/maven/plugin/sass/CompilationErrors.java
+++ b/src/main/java/org/jasig/maven/plugin/sass/CompilationErrors.java
@@ -1,0 +1,36 @@
+package org.jasig.maven.plugin.sass;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * Utility class for capturing sass/scss compilation errors in ruby
+ * and transporting them into the java world for reporting in maven.
+ */
+public class CompilationErrors implements Iterable<CompilationErrors.CompilationError> {
+    final List<CompilationError> errors = new ArrayList<CompilationError>();
+
+    public void add(String file, String message) {
+        errors.add(new CompilationError(file, message));
+    }
+
+    public boolean hasErrors() {
+        return errors.size() > 0;
+    }
+
+    @Override
+    public Iterator<CompilationError> iterator() {
+        return errors.iterator();
+    }
+
+    public class CompilationError {
+        final String filename;
+        final String message;
+
+        CompilationError(String filename, String message) {
+            this.filename = filename;
+            this.message = message;
+        }
+    }
+}

--- a/src/main/java/org/jasig/maven/plugin/sass/UpdateStylesheetsMojo.java
+++ b/src/main/java/org/jasig/maven/plugin/sass/UpdateStylesheetsMojo.java
@@ -19,8 +19,12 @@
 package org.jasig.maven.plugin.sass;
 
 import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 
+import javax.script.Bindings;
+import javax.script.ScriptContext;
 import javax.script.ScriptEngine;
 import javax.script.ScriptEngineManager;
 import javax.script.ScriptException;
@@ -32,31 +36,46 @@ import org.codehaus.plexus.util.StringUtils;
 
 /**
  * Mojo that compiles SASS Templates into CSS files. Uses JRuby to execute a generated script that calls the SASS GEM
- * 
+ *
  * @goal update-stylesheets
  */
 public class UpdateStylesheetsMojo extends AbstractSassMojo {
-    
+
     /**
      * @parameter expression="${encoding}" default-value="${project.build.directory}/${project.build.finalName}
      * @required
      */
     private File baseOutputDirectory;
 
+    /**
+     * Fail the build if errors occur during compilation of sass/scss templates.
+     *
+     * @parameter default-value="false"
+     */
+    private boolean failOnError;
 
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
         final Log log = this.getLog();
-        
+
         final String sassScript = buildSassScript();
         log.debug("SASS Ruby Script:\n" + sassScript);
-        
+
         //Execute the SASS Compliation Ruby Script
         log.info("Compiling SASS Templates");
         final ScriptEngineManager scriptEngineManager = new ScriptEngineManager();
         final ScriptEngine jruby = scriptEngineManager.getEngineByName("jruby");
         try {
             jruby.eval(sassScript);
+            final CompilationErrors compilationErrors = (CompilationErrors) jruby.getBindings(ScriptContext.ENGINE_SCOPE).get("compilation_errors");
+            if (compilationErrors.hasErrors()) {
+                for (CompilationErrors.CompilationError error: compilationErrors) {
+                    log.error("Compilation of template " + error.filename + " failed: " + error.message);
+                }
+                if (failOnError) {
+                    throw new MojoFailureException("SASS compilation encountered errors (see above for details).");
+                }
+            }
         }
         catch (final ScriptException e) {
             throw new MojoExecutionException("Failed to execute SASS ruby script:\n" + sassScript, e);
@@ -65,9 +84,15 @@ public class UpdateStylesheetsMojo extends AbstractSassMojo {
 
     protected String buildSassScript() throws MojoExecutionException {
         final Log log = this.getLog();
-        
+
         final StringBuilder sassScript = new StringBuilder();
         buildSassOptions(sassScript);
+
+        // set up compilation error reporting
+        sassScript.append("require 'java'\n");
+        sassScript.append("java_import org.jasig.maven.plugin.sass.CompilationErrors\n");
+        sassScript.append("$compilation_errors = CompilationErrors.new\n");
+        sassScript.append("Sass::Plugin.on_compilation_error {|error, template, css| $compilation_errors.add(template, error.message) }\n");
 
         //Add the SASS Template locations
         final Set<String> sassDirectories = this.findSassDirs();
@@ -84,7 +109,7 @@ public class UpdateStylesheetsMojo extends AbstractSassMojo {
             .append(sassDestDirStr).append("')\n");
         }
         sassScript.append("Sass::Plugin.update_stylesheets");
-        
+
         return sassScript.toString();
     }
 }


### PR DESCRIPTION
Thank you for the sass-maven-plugin. I find it very useful and simple to use.

I missed the functionality to fail a maven build if the sass/scss compilation fails. This change implements reporting of compilation errors in the maven output and a new configuration option "failOnError", which allows failing the maven build if set to true. For backwards compatibility I set its default value to false.

I would be happy to see this change in the next release of the sass-maven-plugin!

Thanks,
Julian
