### PR TITLE
Preperation for release 1.0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 sass-maven-plugin
 =================
 
-Maven Plugin to Compile SASS files into CSS. Plugin version 1.0.2 uses jRuby 1.6.8 and SASS 3.2.5
+Maven Plugin to Compile SASS files into CSS. Plugin version 1.0.3 uses jRuby 1.6.8 and SASS 3.2.6
 
-See here for more details: http://developer.jasig.org/projects/sass-maven-plugin/1.0.2/plugin-info.html
+See here for more details: http://developer.jasig.org/projects/sass-maven-plugin/1.0.3/plugin-info.html

--- a/pom.xml
+++ b/pom.xml
@@ -102,31 +102,54 @@
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
                 <version>1.2.1</version>
-                <configuration>
-                    <executable>java</executable>
-                    <arguments>
-                        <argument>-classpath</argument>
-                        <classpath />
-                        <argument>org.jruby.Main</argument>
-                        <argument>-S</argument>
-                        <argument>gem</argument>
-                        <argument>install</argument>
-                        <argument>-i</argument>
-                        <argument>${project.build.directory}/classes</argument>
-                        <argument>--no-rdoc</argument>
-                        <argument>--no-ri</argument>
-                        <argument>--version</argument>
-                        <argument>${compass.version}</argument>
-                        <argument>compass</argument>
-                    </arguments>
-                </configuration>
                 <executions>
                     <execution>
-                        <id>install-gems</id>
+                        <id>install-compass</id>
                         <phase>generate-resources</phase>
                         <goals>
                             <goal>exec</goal>
                         </goals>
+                        <configuration>
+                            <executable>java</executable>
+                            <arguments>
+                                <argument>-classpath</argument>
+                                <classpath />
+                                <argument>org.jruby.Main</argument>
+                                <argument>-S</argument>
+                                <argument>gem</argument>
+                                <argument>install</argument>
+                                <argument>-i</argument>
+                                <argument>${project.build.directory}/classes</argument>
+                                <argument>--no-rdoc</argument>
+                                <argument>--no-ri</argument>
+                                <argument>--version</argument>
+                                <argument>${compass.version}</argument>
+                                <argument>compass</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>install-rb-fsevent</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>java</executable>
+                            <arguments>
+                                <argument>-classpath</argument>
+                                <classpath />
+                                <argument>org.jruby.Main</argument>
+                                <argument>-S</argument>
+                                <argument>gem</argument>
+                                <argument>install</argument>
+                                <argument>-i</argument>
+                                <argument>${project.build.directory}/classes</argument>
+                                <argument>--no-rdoc</argument>
+                                <argument>--no-ri</argument>
+                                <argument>rb-fsevent</argument>
+                            </arguments>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/src/main/java/org/jasig/maven/plugin/sass/AbstractSassMojo.java
+++ b/src/main/java/org/jasig/maven/plugin/sass/AbstractSassMojo.java
@@ -40,6 +40,23 @@ public abstract class AbstractSassMojo extends AbstractMojo {
 
     /**
      * Sources for compilation with their destination directory containing SASS files.
+     * Example configuration
+     * <pre>
+     * &lt;resources>
+     *   &lt;resource>
+     *     &lt;source>
+     *       &lt;directory>${basedir}/src/main/resources/css&lt;/directory>
+     *       &lt;includes>
+     *         &lt;include>&#42;&#42;&lt;/include>
+     *       &lt;/includes>
+     *       &lt;excludes>
+     *         &lt;exclude>&#42;&#42;/watch-settings&lt;/exclude>
+     *       &lt;/excludes>
+     *     &lt;/source>
+     *     &lt;destination>${project.build.directory}/css&lt;/destination>
+     *   &lt;/resource>
+     * &lt;/resources>
+     * </pre>
      *
      * @parameter
      * @required


### PR DESCRIPTION
SASS 3.2.6 is out, this fixes the watch mojo because of the update of the 'Listen' gem.
I also added some documentation (an example) for the new resources configuration.
Fixed a warning from the new Listen version (see commit statements below).

Commit statements:
Update: readme ready for 1.0.3 release
Fix: Added gem 'rb-fsevent' because Listen gem gives the following warning:
[Listen warning]:
  Missing dependency 'rb-fsevent' (version '~> 0.9.1')!
  Please run the following to satisfy the dependency:
    gem install --version '~> 0.9.1' rb-fsevent

  For a better performance, it's recommended that you satisfy the missing dependency.
  Listen will be polling changes. Learn more at https://github.com/guard/listen#polling-fallback.
