### PR TITLE
Added .svn folders to exclude list

### DIFF
--- a/src/main/java/org/jasig/maven/plugin/sass/Resource.java
+++ b/src/main/java/org/jasig/maven/plugin/sass/Resource.java
@@ -20,7 +20,6 @@ package org.jasig.maven.plugin.sass;
 
 import java.io.File;
 import java.util.LinkedHashMap;
-import java.util.List;
 
 import org.apache.commons.io.FilenameUtils;
 import org.apache.maven.model.FileSet;


### PR DESCRIPTION
When checking out scss sources from subversion the .svn folders are automatically watched when not added to the exclude list. This fix prevents watching .svn folders by default
