### PR TITLE
adding threadsafe system property for jruby

### DIFF
--- a/src/main/java/org/jasig/maven/plugin/sass/UpdateStylesheetsMojo.java
+++ b/src/main/java/org/jasig/maven/plugin/sass/UpdateStylesheetsMojo.java
@@ -44,6 +44,7 @@ public class UpdateStylesheetsMojo extends AbstractSassMojo {
 
         //Execute the SASS Compilation Ruby Script
         log.info("Compiling SASS Templates");
+	System.setProperty("org.jruby.embed.localcontext.scope", "threadsafe");
         final ScriptEngineManager scriptEngineManager = new ScriptEngineManager();
         final ScriptEngine jruby = scriptEngineManager.getEngineByName("jruby");
         try {


### PR DESCRIPTION
updateStylesheetMojo is failing when using multithreaded maven builds (mvn install -T 3). using a threadsafe jruby engine fixes the problem
