### PR TITLE
use gem-maven-plugin and exclude unnecessary resources

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -149,6 +149,7 @@
                             <installRDoc>false</installRDoc>
                             <installRI>false</installRI>
                             <includeOpenSSL>false</includeOpenSSL>
+                            <includeRubygemsInTestResources>false</includeRubygemsInTestResources>
                             <jrubyVersion>${jruby.version}</jrubyVersion>
                         </configuration>
                     </execution>


### PR DESCRIPTION
Refactored pom to use the gem-maven-plugin for downloading gems. The advantage is that gems are only downloaded if not already present (`mvn package` is about 4 times faster than `mvn clean package`).

Additionally, unnecessary resources are excluded from the plugin artifact, thus reducing its size from 4.7M to 719K.

Not sure if the eclipse lifecycle mappings are ok. I use Intellij.
