### PR TITLE
remove wrong documentation

### DIFF
--- a/src/main/java/org/jasig/maven/plugin/sass/AbstractSassMojo.java
+++ b/src/main/java/org/jasig/maven/plugin/sass/AbstractSassMojo.java
@@ -47,12 +47,6 @@ public abstract class AbstractSassMojo extends AbstractMojo {
      *   &lt;resource>
      *     &lt;source>
      *       &lt;directory>${basedir}/src/main/resources/css&lt;/directory>
-     *       &lt;includes>
-     *         &lt;include>&#42;&#42;&lt;/include>
-     *       &lt;/includes>
-     *       &lt;excludes>
-     *         &lt;exclude>&#42;&#42;/watch-settings&lt;/exclude>
-     *       &lt;/excludes>
      *     &lt;/source>
      *     &lt;destination>${project.build.directory}/css&lt;/destination>
      *   &lt;/resource>


### PR DESCRIPTION
sass-maven-plugin calls sass compiler with directories (see getDirectoriesAndDestinations) and not with single files. Upon this it doesn't make any sense to include or exclude directories because sass compiler always scans all directories recursive. It is even worse to set include to *\* because all sub directories are added and compiled multiple times. Let's say project has this structure:

```
[FOO]
    foo.scss
    [BAR]
        bar.scss
```

If I configure directory to `${basedir}/FOO` and `<include>**</include>` sass-maven-compiler adds `FOO => FOO` and `FOO/BAR => FOO/BAR`. `bar.scss` gets compiled two times.

Maybe it would be better to change to file approach (instead of directories) so user can get full control of includes/excludes and of which file to compile where. But this would break current configs so maybe for 2.0.0

IMO it's OK to correct documentation for the moment.
