### PR TITLE
Fix for issue #47, ENV["GEM_PATH"] is not an array when set

### DIFF
--- a/src/main/java/org/jasig/maven/plugin/sass/AbstractSassMojo.java
+++ b/src/main/java/org/jasig/maven/plugin/sass/AbstractSassMojo.java
@@ -208,10 +208,16 @@ public abstract class AbstractSassMojo extends AbstractMojo {
             for (final String gemPath : gemPaths) {
                 sassScript.append("    '").append(gemPath).append("',\n");
             }
+
+            final String gemPath = System.getenv("GEM_PATH");
+            if (gemPath != null) {
+                for (final String p : gemPath.split(File.pathSeparator)) {
+                    sassScript.append("    '").append(p).append("',\n");
+                }
+            }
             sassScript.setLength(sassScript.length() - 2); // remove trailing comma
             sassScript.append("\n");
             sassScript.append("] }\n");
-            sassScript.append("env['GEM_PATH'] += ENV['GEM_PATH'] unless ENV['GEM_PATH'].nil?\n");
             sassScript.append("Gem.paths = env\n");
         }
 


### PR DESCRIPTION
The problem is that when ENV["GEM_PATH"] is set, it's just a string containing a colon-separated list of paths (or semicolon, on Windows).  When it's nil, the code in the sass-maven-plugin works, because it just does nothing.  When it's set, you're trying to add the string to the env array you've already created.

Since we already have the environment in the Java side, I figured the easiest fix is to just ignore ENV["GEM_PATH"] on the ruby side, and instead append it to the env["GEM_PATH"] you're already building up in the sassScript StringBuilder, since it's basically already doing that anyways.  ;)
