### PR TITLE
Add sassConfigFile option to load configs from config.rb file

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,5 @@ sass-maven-plugin
 Maven Plugin to Compile SASS files into CSS. Plugin version 1.0.3 uses jRuby 1.6.8, Compass 0.12.2, and SASS 3.2.6
 
 See here for more details: http://developer.jasig.org/projects/sass-maven-plugin/1.1.1/plugin-info.html
+
+Add project configuration file parameter for Compass

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.jasig.maven</groupId>
     <artifactId>sass-maven-plugin</artifactId>
-    <version>1.1.2-SNAPSHOT</version>
+    <version>1.1.3-SNAPSHOT</version>
     <packaging>maven-plugin</packaging>
 
     <name>SASS Compiler Plugin</name>

--- a/src/main/java/org/jasig/maven/plugin/sass/AbstractSassMojo.java
+++ b/src/main/java/org/jasig/maven/plugin/sass/AbstractSassMojo.java
@@ -226,7 +226,7 @@ public abstract class AbstractSassMojo extends AbstractMojo {
             log.info("Running with Compass enabled.");
             sassScript.append("require 'compass'\n");
             sassScript.append("require 'compass/exec'\n");
-            sassScript.append("Compass.add_project_configuration \n");
+            sassScript.append("Compass.add_project_configuration " + this.sassSourceDirectory.toString() + " \n");
             this.sassOptions.put("load_paths", "Compass.configuration.sass_load_paths");
             // manually specify these paths
             sassScript.append("Compass::Frameworks.register_directory('jar:'+ File.join(Compass.base_directory, 'frameworks/compass'))\n");

--- a/src/main/java/org/jasig/maven/plugin/sass/AbstractSassMojo.java
+++ b/src/main/java/org/jasig/maven/plugin/sass/AbstractSassMojo.java
@@ -141,7 +141,15 @@ public abstract class AbstractSassMojo extends AbstractMojo {
      * @required
      */
     protected File sassSourceDirectory;
-    
+
+   /**
+     * SASS Config File, defaults (src/main/webapp/config.rb)
+     *
+     * @parameter default-value="${basedir}/src/main/webapp/config.rb" 
+     * @required
+     */
+    protected File sassConfigFile;
+ 
     /**
      * Defines files in the source directories to include
      * 
@@ -226,7 +234,7 @@ public abstract class AbstractSassMojo extends AbstractMojo {
             log.info("Running with Compass enabled.");
             sassScript.append("require 'compass'\n");
             sassScript.append("require 'compass/exec'\n");
-            sassScript.append("Compass.add_project_configuration " + this.sassSourceDirectory.toString() + "/config.rb \n");
+            sassScript.append("Compass.add_project_configuration(File.join('" + this.sassConfigFile.toString()+ "'))\n");
             this.sassOptions.put("load_paths", "Compass.configuration.sass_load_paths");
             // manually specify these paths
             sassScript.append("Compass::Frameworks.register_directory('jar:'+ File.join(Compass.base_directory, 'frameworks/compass'))\n");

--- a/src/main/java/org/jasig/maven/plugin/sass/AbstractSassMojo.java
+++ b/src/main/java/org/jasig/maven/plugin/sass/AbstractSassMojo.java
@@ -226,7 +226,7 @@ public abstract class AbstractSassMojo extends AbstractMojo {
             log.info("Running with Compass enabled.");
             sassScript.append("require 'compass'\n");
             sassScript.append("require 'compass/exec'\n");
-            sassScript.append("Compass.add_project_configuration " + this.sassSourceDirectory.toString() + " \n");
+            sassScript.append("Compass.add_project_configuration " + this.sassSourceDirectory.toString() + "/config.rb \n");
             this.sassOptions.put("load_paths", "Compass.configuration.sass_load_paths");
             // manually specify these paths
             sassScript.append("Compass::Frameworks.register_directory('jar:'+ File.join(Compass.base_directory, 'frameworks/compass'))\n");


### PR DESCRIPTION
Current sass-maven-plugin doesn't support loading configs from config.rb directly so I fixed it by adding a new sassConfigFile option.
