### PR TITLE
Workaround for broken gemspec in compass gem

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,7 @@
         <project.build.targetVersion>1.6</project.build.targetVersion>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <compass.version>0.12.2</compass.version>
+        <sass.version>3.2.16</sass.version>
         <inotify.version>0.8.8</inotify.version>
         <fsevent.version>0.9.3</fsevent.version>
         <jruby.version>1.6.8</jruby.version>
@@ -59,6 +60,14 @@
             <groupId>rubygems</groupId>
             <artifactId>compass</artifactId>
             <version>${compass.version}</version>
+            <scope>provided</scope>
+            <type>gem</type>
+        </dependency>
+        <!-- workaround for broken gemspec https://github.com/chriseppstein/compass/issues/1513 -->
+        <dependency>
+            <groupId>rubygems</groupId>
+            <artifactId>sass</artifactId>
+            <version>${sass.version}</version>
             <scope>provided</scope>
             <type>gem</type>
         </dependency>


### PR DESCRIPTION
latest version of sass gem is not compatible with compass 0.12.2. Workaround is to specify compatible version explicitly

see https://github.com/chriseppstein/compass/issues/1339, https://github.com/chriseppstein/compass/issues/1513

"i think its because we didn't set an upper end dependency in the gemspec this problem should go away once 1.0 is released /cc @chriseppstein"
