### PR TITLE
Compass settings and explicit Sass version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.jasig.maven</groupId>
     <artifactId>sass-maven-plugin</artifactId>
-    <version>1.1.1</version>
+    <version>1.1.1.PATCHED-SNAPSHOT</version>
     <packaging>maven-plugin</packaging>
 
     <name>SASS Compiler Plugin</name>
@@ -27,6 +27,7 @@
         <project.build.targetVersion>1.6</project.build.targetVersion>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <compass.version>0.12.2</compass.version>
+	<sass.version>3.2.19</sass.version>
         <inotify.version>0.8.8</inotify.version>
         <fsevent.version>0.9.3</fsevent.version>
         <jruby.version>1.6.8</jruby.version>
@@ -59,6 +60,13 @@
             <groupId>rubygems</groupId>
             <artifactId>compass</artifactId>
             <version>${compass.version}</version>
+            <scope>provided</scope>
+            <type>gem</type>
+        </dependency>
+        <dependency>
+            <groupId>rubygems</groupId>
+            <artifactId>sass</artifactId>
+	    <version>${sass.version}</version>
             <scope>provided</scope>
             <type>gem</type>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -10,29 +10,29 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.jasig.maven</groupId>
     <artifactId>sass-maven-plugin</artifactId>
-    <version>1.1.1.PATCHED-SNAPSHOT</version>
+    <version>1.1.1.PATCHED</version>
     <packaging>maven-plugin</packaging>
 
     <name>SASS Compiler Plugin</name>
     <description>Maven Plugin that compiles SASS files</description>
-    
+
     <scm>
         <connection>scm:git:git://github.com/Jasig/sass-maven-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:Jasig/sass-maven-plugin.git</developerConnection>
         <url>https://github.com/Jasig/sass-maven-plugin</url>
     </scm>
-    
+
     <properties>
         <project.build.sourceVersion>1.6</project.build.sourceVersion>
         <project.build.targetVersion>1.6</project.build.targetVersion>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <compass.version>0.12.2</compass.version>
-	<sass.version>3.2.19</sass.version>
+        <sass.version>3.2.19</sass.version>
         <inotify.version>0.8.8</inotify.version>
         <fsevent.version>0.9.3</fsevent.version>
         <jruby.version>1.6.8</jruby.version>
     </properties>
-    
+
     <dependencies>
         <dependency>
             <groupId>org.jruby</groupId>
@@ -66,7 +66,7 @@
         <dependency>
             <groupId>rubygems</groupId>
             <artifactId>sass</artifactId>
-	    <version>${sass.version}</version>
+            <version>${sass.version}</version>
             <scope>provided</scope>
             <type>gem</type>
         </dependency>

--- a/src/main/java/org/jasig/maven/plugin/sass/AbstractSassMojo.java
+++ b/src/main/java/org/jasig/maven/plugin/sass/AbstractSassMojo.java
@@ -135,6 +135,14 @@ public abstract class AbstractSassMojo extends AbstractMojo {
     protected boolean useCompass;
 
     /**
+     * Compass Config File, defaults (${project.basedir}/config.rb)
+     *
+     * @parameter default-value="${project.basedir}/config.rb"
+     * @required
+     */
+    protected File compassConfigFile;
+
+    /**
      * Directory containing SASS files, defaults to the Maven Web application sources directory (src/main/webapp)
      *
      * @parameter default-value="${basedir}/src/main/webapp" 
@@ -226,7 +234,7 @@ public abstract class AbstractSassMojo extends AbstractMojo {
             log.info("Running with Compass enabled.");
             sassScript.append("require 'compass'\n");
             sassScript.append("require 'compass/exec'\n");
-            sassScript.append("Compass.add_project_configuration \n");
+            sassScript.append("Compass.add_project_configuration(File.join('" + this.compassConfigFile.toString()+ "'))\n");
             this.sassOptions.put("load_paths", "Compass.configuration.sass_load_paths");
             // manually specify these paths
             sassScript.append("Compass::Frameworks.register_directory('jar:'+ File.join(Compass.base_directory, 'frameworks/compass'))\n");


### PR DESCRIPTION
The current version of Compass has a dependency to Sass version 3.3 which is not compatible. Therefore I explicitly set the version of Sass to the last compatible version 3.2.19.

Compass settings 'config.rb' can be set in the configuration. See #43 #51.
